### PR TITLE
Support http proxy configured via standard System property

### DIFF
--- a/src/main/java/org/tripside/stash/plugin/hook/postreceive/notification/flowdock/FlowdockPostReceiveNotificationHook.java
+++ b/src/main/java/org/tripside/stash/plugin/hook/postreceive/notification/flowdock/FlowdockPostReceiveNotificationHook.java
@@ -174,6 +174,10 @@ public class FlowdockPostReceiveNotificationHook implements AsyncPostReceiveRepo
 	{
 		URI uri = new URI("https://api.flowdock.com/v1/git/" + token);
 		Resty r = new Resty();
+		if (System.getProperty("http.proxyHost") != null)
+		{
+			r.setOptions(Resty.Option.proxy(System.getProperty("http.proxyHost"), Integer.getInteger("http.proxyPort", 80)));
+		}
 
 		TextResource res = r.text(uri, form(data("payload", content(new JSONObject (payload)))));
 	}


### PR DESCRIPTION
https://answers.atlassian.com/questions/246968/flowdock-post-receive-notification-hook-is-not-working-in-proxy-but-upm-and-marketplace-are-connecting
